### PR TITLE
[L1-114] Update component short descriptions

### DIFF
--- a/components/ex-iceberg/component_config/component_short_description.md
+++ b/components/ex-iceberg/component_config/component_short_description.md
@@ -1,1 +1,1 @@
-Apache Iceberg is an open table format.
+Extracts data from Apache Iceberg tables.

--- a/components/wr-iceberg/component_config/component_short_description.md
+++ b/components/wr-iceberg/component_config/component_short_description.md
@@ -1,1 +1,1 @@
-Apache Iceberg is an open table format.
+Writes data to Apache Iceberg tables.


### PR DESCRIPTION
Batch cleanup of component short descriptions (the one-liner in the platform component list) - they described the vendor product instead of what the component does.

Tracked in https://linear.app/keboola/issue/L1-114/make-component-short-descriptions-consistent-support-13792 (SUPPORT-13792). Reviewed and approved by Component Factory.

Changes in this repo:
- `keboola.ex-iceberg` -> Extracts data from Apache Iceberg tables.
- `keboola.wr-iceberg` -> Writes data to Apache Iceberg tables.

One-line content change to `component_config/component_short_description.md`. Please review wording and merge.